### PR TITLE
Init and update settings data object

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ Additionally, in case your tool comes with a frontend (like in the quote-card ex
 ### Quickstart
 
 1. Clone the repo
+
 2. In `package.json` set the `name` to your tool's name prefixed with `riga-` (eg. `riga-quote-card`)
+
 3. Run `npm run dev` for development
+
 4. Build out the settings component `src/lib/components/Settings.svelte` (see below for more info)
+
 5. Once you're happy with your component run `npm run package`. This will produce a `./dist` folder crucially including an `index.js` file exporting your `Settings` component for consumption in the RIGA Editor once npm installed.
 
 ### Writing Settings component
@@ -81,9 +85,33 @@ You can control the layout and dimensions of your individual settings or setting
   <textarea class="rt-input max-w-none" />
   ```
 
-#### How to view a setting?
+#### How to view your settings component?
 
 Run `npm run dev` to view your changes on the dev server.
+
+#### How to update the settings data?
+
+The Settings's core task is to capture settings a user will set or change via the component's inputs.
+
+The capturing mechanic is straight forward. The Settings component receives a [Svelte writable store](https://svelte.dev/docs#run-time-svelte-store-writable) which can be updated on input change. For example:
+
+```html
+<script>
+	// The settings store passed in by the Editor:
+	export let settings;
+</script>
+
+<!-- Update the values for the settings' `font_size` property -->
+<input name="font-size" bind:value="{$settings.font_size}" />
+```
+
+When using predefined components, pass the `settings` store and the property name to update:
+
+```html
+<DropDown settings={settings} setting={'font_size'} //... />
+```
+
+_See the [Settings component implementation](./src/lib/components/Settings.svelte) for a complete implementation across multiple inputs._
 
 #### Utilities
 

--- a/src/app.css
+++ b/src/app.css
@@ -23,6 +23,11 @@
 	.rt-input {
 		@apply max-w-[8rem] rounded border-gray-200 bg-gray-5 py-[0.25rem] text-sm;
 	}
+
+	/* Other classes (not used for Settings) */
+	.btn-base {
+		@apply mx-2 rounded-lg border border-gray-100 bg-gradient-to-tr px-4 py-1 shadow-md transition hover:scale-102 hover:shadow-lg active:shadow-sm;
+	}
 }
 
 @layer base {

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,6 +1,16 @@
+<!-- This is the Settings component written by the tool developer. -->
+
 <script lang="ts">
+	import type { SettingsWritable } from '$types/index.js';
 	import ColorPicker from './controls/ColorPicker.svelte';
 	import DropDown from './controls/Dropdown.svelte';
+
+	// `settings` data as only component prop.
+	export let settings: SettingsWritable;
+
+	// You can (but don't have to) init your values here. Note that if you do
+	// previously stored settings on `$settings` will be overwritten.
+	$settings.quote_symbol_color = '#0000ff';
 
 	// Dropdown data.
 	const quoteSymbolDropDown = [
@@ -10,34 +20,46 @@
 	];
 </script>
 
-<!-- Notes below -->
-<form action="" class="rt-form">
+<form class="rt-form">
 	<fieldset class="rt-fieldset">
 		<legend class="rt-legend">Card Settings</legend>
 		<div class="rt-setting w-full">
 			<label for="quote-text" class="rt-label">Quote text</label>
-			<textarea name="quote-text" id="quote-text" cols="10" rows="3" class="rt-input max-w-none" />
+			<textarea
+				name="quote-text"
+				id="quote-text"
+				cols="10"
+				rows="3"
+				class="rt-input font-skolar max-w-none text-gray-500"
+				bind:value={$settings.quote_text}
+			/>
 		</div>
 		<div class="rt-setting">
-			<DropDown label="Quote symbol" list={quoteSymbolDropDown} />
+			<DropDown
+				label="Quote symbol"
+				list={quoteSymbolDropDown}
+				{settings}
+				setting={'quote_symbol'}
+			/>
 		</div>
 		<div class="rt-setting">
 			<label for="quote-text-size" class="rt-label">Text size</label>
-			<input type="number" name="quote-text-size" id="quote-text-size" class="rt-input" />
+			<input
+				type="number"
+				name="quote-text-size"
+				id="quote-text-size"
+				class="rt-input"
+				bind:value={$settings.quote_text_size}
+			/>
 		</div>
 		<div class="rt-setting">
-			<ColorPicker label="Text color" />
+			<ColorPicker label="Text color" {settings} setting="text_color" />
 		</div>
 		<div class="rt-setting">
-			<ColorPicker label="Background color" />
+			<ColorPicker label="Background color" {settings} setting="background_color" />
 		</div>
 		<div class="rt-setting">
-			<ColorPicker label="Quote symbol color" />
+			<ColorPicker label="Quote symbol color" {settings} setting="quote_symbol_color" />
 		</div>
 	</fieldset>
 </form>
-
-<!-- You can 
-	 - use pre-built components from `controls` (TODO: this will come from library)
-	 - build your own components 
-	 - or build settings directly in here (within an `.rt-setting` wrapper div) -->

--- a/src/lib/components/controls/ColorPicker.svelte
+++ b/src/lib/components/controls/ColorPicker.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { setID } from '../../utils/index.js';
+	import type { SettingsWritable } from '$types/index.js';
 
 	export let label: string = 'Label';
+	export let settings: SettingsWritable;
+	export let setting: string;
 
 	// Required for unique element id's:
 	const id = setID();
 
-	let color: string = '#cccccc';
+	// Init colors to base colour if no setting property defined.
+	let color: string = $settings[setting] ? String($settings[setting]) : '#cccccc';
 	let hexInput = '';
 
 	// Helper function for hex validation.
 	function isHexColor(hex: string): boolean {
 		return /^#(?:[0-9a-fA-F]{3}){1,2}$/.test(hex);
+	}
+
+	function updateSetting() {
+		$settings[setting] = color;
 	}
 
 	// Update the color when a valid hex value is entered.
@@ -22,6 +30,7 @@
 			return;
 		}
 		color = hexInput;
+		updateSetting();
 	}
 
 	onMount(() => {
@@ -52,7 +61,10 @@
 			id={`${id}-color`}
 			class="absolute top-0 h-4 w-4 -translate-y-1/2 opacity-0"
 			bind:value={color}
-			on:change={() => (hexInput = color)}
+			on:change={() => {
+				hexInput = color;
+				updateSetting();
+			}}
 		/>
 	</div>
 </div>

--- a/src/lib/components/controls/Dropdown.svelte
+++ b/src/lib/components/controls/Dropdown.svelte
@@ -11,13 +11,15 @@
 		{ value: 'one', label: 'one' },
 		{ value: 'two', label: 'two' }
 	];
+	export let settings: any;
+	export let setting: string;
 
 	// Required for unique element id's:
 	const id = setID();
 </script>
 
 <label for={id} class="rt-label">{label}</label>
-<select name={id} {id} class="rt-input">
+<select name={id} {id} class="rt-input" bind:value={$settings[setting]}>
 	{#each list as item}
 		<option value={item.value}>{item.label}</option>
 	{/each}

--- a/src/lib/components/wrap/SettingsWrap.svelte
+++ b/src/lib/components/wrap/SettingsWrap.svelte
@@ -1,0 +1,31 @@
+<!-- This component is just emulating the behavior of the Editor:
+	   (1) passing a settings object into the Settings component and 
+		 (2) stringifying the object before persisting it in storage -->
+
+<script lang="ts">
+	import Settings from '$lib/components/Settings.svelte';
+	import { writable } from 'svelte/store';
+	import type { SettingsWritable } from '$types/index.js';
+
+	// `settings` can but don't have to be value initialised.
+	const settings: SettingsWritable = writable({
+		quote_text: 'I am a quote'
+	});
+
+	function save() {
+		// Build JSON settings object to send on.
+		const settings_json: { [key: string]: any } = {};
+		for (const [key, value] of Object.entries($settings)) {
+			console.log(key, value);
+			settings_json[key] = value;
+		}
+		console.log(JSON.stringify(settings_json));
+		// TODO send settings to wherever
+	}
+</script>
+
+<div class=" font-skolar-sans m-4 flex items-center justify-between">
+	<div class="text-gray-400">Settings</div>
+	<button class="btn-base" on:click={save}>Save</button>
+</div>
+<Settings {settings} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Settings from '$lib/components/Settings.svelte';
+	import SettingsWrap from '$lib/components/wrap/SettingsWrap.svelte';
 	import { onMount } from 'svelte';
 
 	// This is a temporary editor markup. Ultimately we want to have the
@@ -53,7 +53,7 @@
 			</div>
 		</div>
 		<div class="w-5/6 border border-gray-100 shadow-xl md:w-2/5">
-			<Settings />
+			<SettingsWrap />
 		</div>
 	</div>
 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+import type { Writable } from 'svelte/store';
+
+type SettingsValue = string | number;
+type Settings = { [key: string]: SettingsValue };
+export type SettingsWritable = Writable<Settings>;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,7 +15,10 @@ const config = {
 		// and set `strict` (== prerender all pages) to `false` here.
 		adapter: adapter({
 			strict: false
-		})
+		}),
+		alias: {
+			'$types': './src/types',
+		}
 	}
 };
 


### PR DESCRIPTION
This PR adds a mechanic for the Settings component to update a `settings` object capturing the changed data.

Values can be initialised either in the editor (which is emulated by the `SettingsWrap` component), in the `Settings` component of in the controls. The mechanic is flexible in that the developer can ultimately choose how to update the data.