### PR TITLE
Unignore tool config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-/src/riga-tool.config.ts
+# /src/riga-tool.config.ts
 
 # /dist can be gitignored when npm installed (as covered by package.json's 
 # `files` array) but should NOT be gitignored when git+ssh installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "riga-editor-tool-quote-card",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "riga-editor-tool-quote-card",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^2.0.2",
 				"@sveltejs/kit": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "riga-editor-tool-quote-card",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"scripts": {
 		"predev": "npm run generateConfig",
 		"prebuild": "npm run generateConfig",

--- a/src/riga-tool.config.ts
+++ b/src/riga-tool.config.ts
@@ -1,0 +1,16 @@
+export default {
+  "name": "Quote Card",
+  "slug": "quote_card",
+  "category": "Editorial",
+  "package_name": "riga-editor-tool-quote-card",
+  "image": "https://i.ibb.co/JkdZrXj/Blueprint-0.jpg",
+  "url": "http://localhost:5174/quote-card",
+  "settings": {
+    "quote_text": "Hello",
+    "quote_symbol": "&#10078;",
+    "quote_text_size": 3,
+    "quote_text_color": "#666666",
+    "quote_symbol_color": "#f0f0f0",
+    "quote_background_color": "#fcfcfc"
+  }
+};


### PR DESCRIPTION
  After the previous commit, the editor can't find the
  config js file, which I can't blame it for as I can't see
  it either. This commit tests unignoring the file...